### PR TITLE
Implemented STACKED orientation

### DIFF
--- a/src/main/java/org/vaadin/addons/taefi/component/ToggleButtonGroup.java
+++ b/src/main/java/org/vaadin/addons/taefi/component/ToggleButtonGroup.java
@@ -24,7 +24,7 @@ import java.util.stream.Stream;
 public class ToggleButtonGroup<T> extends CustomField<T> {
 
     public enum Orientation {
-        HORIZONTAL, VERTICAL
+        HORIZONTAL, VERTICAL, STACKED
     }
 
     private List<T> items;
@@ -95,6 +95,10 @@ public class ToggleButtonGroup<T> extends CustomField<T> {
         }
 
         addButtonsToLayout(buttons);
+        
+        if(orientation == Orientation.STACKED) {
+            setValue(items.get(0), false);
+        }
     }
 
     protected void addButtonsToLayout(Button[] buttons) {
@@ -159,7 +163,15 @@ public class ToggleButtonGroup<T> extends CustomField<T> {
     }
 
     private String getOrientationStylePostfix() {
-        return orientation == Orientation.HORIZONTAL ? "h" : "v";
+        switch(orientation) {
+        case HORIZONTAL:
+            return "h";
+        case STACKED:
+            return "s";
+        case VERTICAL:
+            return "v";
+        default: throw new IllegalArgumentException();
+        }
     }
 
     private Comparator<T> getDefaultComparator() {
@@ -186,7 +198,13 @@ public class ToggleButtonGroup<T> extends CustomField<T> {
             Serializable selectedValueId = itemIdGenerator.apply(selectedValue);
             Serializable previousValueId = itemIdGenerator.apply(getValue());
             if (Objects.equals(selectedValueId, previousValueId)) {
-                setValue(null, event.isFromClient());
+                if(orientation == Orientation.STACKED) {
+                    int itemIndex = items.indexOf(selectedValue)+1;
+                    T nextItem = items.get(itemIndex == items.size() ? 0 : itemIndex);
+                    setValue(nextItem, event.isFromClient());
+                }
+                else setValue(null, event.isFromClient());
+                
                 return;
             }
         }

--- a/src/main/resources/META-INF/resources/frontend/addons-styles/toggle-button-group.css
+++ b/src/main/resources/META-INF/resources/frontend/addons-styles/toggle-button-group.css
@@ -3,6 +3,14 @@
 
 }
 
+.toggle-button-group-button-s:not([theme~=primary]) {
+	display:none;
+}
+
+.toggle-button-group-button-s[theme~=primary] {
+	display: unset;
+}
+
 .toggle-button-group-button-h {
     border-style: solid;
     border-color: var(--_lumo-button-primary-background-color, var(--lumo-primary-color));

--- a/src/test/java/org/vaadin/addons/taefi/component/ToggleButtonGroupView.java
+++ b/src/test/java/org/vaadin/addons/taefi/component/ToggleButtonGroupView.java
@@ -226,9 +226,19 @@ public class ToggleButtonGroupView extends VerticalLayout {
             case RIGHT -> VaadinIcon.ALIGN_RIGHT.create();
         });
         group110.setItemLabelGenerator(textAlignment -> "");
+        
+        ToggleButtonGroup<TextAlignment> group1101 = new ToggleButtonGroup<>("Alignment:");
+        group1101.setItems(TextAlignment.values());
+        group1101.setItemIconGenerator(align -> switch (align) {
+            case LEFT -> VaadinIcon.ALIGN_LEFT.create();
+            case CENTER -> VaadinIcon.ALIGN_CENTER.create();
+            case RIGHT -> VaadinIcon.ALIGN_RIGHT.create();
+        });
+        group1101.setItemLabelGenerator(textAlignment -> "");
+        group100.setOrientation(ToggleButtonGroup.Orientation.STACKED);
 
 
-        VerticalLayout halfLayout = new VerticalLayout(line10, line15, group20, group30, line40, line50, group60, group70, group80, line90, group100, group110);
+        VerticalLayout halfLayout = new VerticalLayout(line10, line15, group20, group30, line40, line50, group60, group70, group80, line90, group100, group110,group1101);
         halfLayout.setId("parent-layout");
         halfLayout.getStyle().set("width", "50%");
         halfLayout.getStyle().set("border", "solid red 1px");

--- a/src/test/java/org/vaadin/addons/taefi/component/ToggleButtonGroupView.java
+++ b/src/test/java/org/vaadin/addons/taefi/component/ToggleButtonGroupView.java
@@ -217,6 +217,8 @@ public class ToggleButtonGroupView extends VerticalLayout {
         );
         group100.setId("group100");
         group100.setOrientation(ToggleButtonGroup.Orientation.VERTICAL);
+        
+        
 
         ToggleButtonGroup<TextAlignment> group110 = new ToggleButtonGroup<>("Alignment:");
         group110.setItems(TextAlignment.values());
@@ -227,18 +229,16 @@ public class ToggleButtonGroupView extends VerticalLayout {
         });
         group110.setItemLabelGenerator(textAlignment -> "");
         
-        ToggleButtonGroup<TextAlignment> group1101 = new ToggleButtonGroup<>("Alignment:");
-        group1101.setItems(TextAlignment.values());
-        group1101.setItemIconGenerator(align -> switch (align) {
-            case LEFT -> VaadinIcon.ALIGN_LEFT.create();
-            case CENTER -> VaadinIcon.ALIGN_CENTER.create();
-            case RIGHT -> VaadinIcon.ALIGN_RIGHT.create();
-        });
-        group1101.setItemLabelGenerator(textAlignment -> "");
-        group100.setOrientation(ToggleButtonGroup.Orientation.STACKED);
+        ToggleButtonGroup<Status> group120 = new ToggleButtonGroup<>(
+                "Status: [orientation = Stacked]",
+                Status.values()
+        );
+        group120.setId("group120");
+        group120.setOrientation(ToggleButtonGroup.Orientation.STACKED);
+        group120.setValue(Status.APPROVED);
+        
 
-
-        VerticalLayout halfLayout = new VerticalLayout(line10, line15, group20, group30, line40, line50, group60, group70, group80, line90, group100, group110,group1101);
+        VerticalLayout halfLayout = new VerticalLayout(line10, line15, group20, group30, line40, line50, group60, group70, group80, line90, group100, group110,group120);
         halfLayout.setId("parent-layout");
         halfLayout.getStyle().set("width", "50%");
         halfLayout.getStyle().set("border", "solid red 1px");


### PR DESCRIPTION
Really liked your toggle button add-on. Added a small feature that I needed and figured id send it along for your consideration as it was a very small change and potentially helpful.

Implemented a STACKED orientation. Using this orientation, only a single button is visible at any time (as if they were stacked on top of one another) and clicking the button iterates through the values. I've found it very useful in exactly the same scenarios as your toggle button.

Implementation is pretty tiny, with really only 3 changes (only applied when in STACKED orientation)
* CSS class and style to hide all but the primary button
* Automatically iterating to the next value when a button is clicked
* Automatically setting the value to the first item. This seemed appropriate since the STACKED orientation implies that one value is always selected.


Added an example of it to the demo view as well.